### PR TITLE
Line 15: switch domain and api_key in init function

### DIFF
--- a/cp_export_api_objects/utils/api_client.py
+++ b/cp_export_api_objects/utils/api_client.py
@@ -12,7 +12,7 @@ class API_client:
     domain: str
     policy_layer: str
 
-    def __init__(self, api_server: str, user: str, password: str, api_key=None, domain=None ) -> None:
+    def __init__(self, api_server: str, user: str, password: str, domain=None, api_key=None ) -> None:
         self.user = user
         self.password = password
         self.api_key = api_key


### PR DESCRIPTION
When working with MDM, the api_key receives the domain argument. 

Side Note: 
Global Policy might not be supported, when parsing Global Policy, the first rule base key does not have rule['name'] in the first line giving a keyerror in cp_layers_rules_to_ansible. 

It does however manage to export the objects before exiting at policy export. 

  File "/home/ramilu/global_export/Ansible_Projects/cp_export_api_objects/utils/cp_layer_rules_to_ansible.py", line 47, in parse_section
    parse_rule(entry['rulebase'], layer)
  File "/home/ramilu/global_export/Ansible_Projects/cp_export_api_objects/utils/cp_layer_rules_to_ansible.py", line 57, in parse_rule
    rule_template = {"name": f"task for rule number: {rule['rule-number']}, Name: {rule['name']}",
KeyError: 'name'